### PR TITLE
link RtlGenRandom and don't include modules when getrandom is enabled

### DIFF
--- a/src/entropy/mod.rs
+++ b/src/entropy/mod.rs
@@ -9,15 +9,15 @@ pub use windows_uwp::entropy_from_system;
 
 /// A 100% safe entropy generator, using (in order of priority) `/dev/urandom`,
 /// `/dev/random`, or the system time.
-#[cfg(unix)]
+#[cfg(all(unix, not(feature = "getrandom")))]
 pub mod unix;
 
 /// An entropy generator for Windows, using WinAPI's `BCryptGenRandom` function.
-#[cfg(all(windows, target_vendor = "uwp"))]
+#[cfg(all(windows, target_vendor = "uwp", not(feature = "getrandom")))]
 pub mod windows_uwp;
 
 /// An entropy generator for Windows, using WinAPI's `RtlGenRandom` function.
-#[cfg(all(windows, not(target_vendor = "uwp")))]
+#[cfg(all(windows, not(target_vendor = "uwp"), not(feature = "getrandom")))]
 pub mod windows;
 
 /// Pull in system entropy using the [`getrandom`](https://crates.io/crates/getrandom) crate.  

--- a/src/entropy/windows.rs
+++ b/src/entropy/windows.rs
@@ -1,6 +1,7 @@
 use super::backup_entropy;
 
 extern "system" {
+	#[link_name = "SystemFunction036"]
 	fn RtlGenRandom(pBuffer: *mut u8, cbBuffer: usize) -> u32;
 }
 


### PR DESCRIPTION
Sorry, didn't have time to [build the commit](https://github.com/aspenluxxxy/nanorand-rs/issues/3#issuecomment-697080826). But here we are. But when trying it I'm getting a linker error:

```
  = note: libnanorand-8720cbc4bdc0a391.rlib(nanorand-8720cbc4bdc0a391.2xtbbocb8f37fkig.rcgu.o) : error LNK2019: unresolved external symbol RtlGenRandom referenced in function _ZN8nanorand7entropy7windows19entropy_from_system17h1ca42bc1b6bdfd28E
          D:\Repo\rune\target\debug\deps\rune_languageserver.exe : fatal error LNK1120: 1 unresolved externals
```

So there's a `#[link_name = "SystemFunction036"]` missing in order to use `RtlGenRandom` (don't even ask!). I'm not entirely sure why it works in CI, but it could be that nightly has better dead code elimination in combination with `lto` (which removes linked libraries that are not used).

To test this going forward it might be worth adding build variants which [does not include the `getrandom` feature](https://github.com/aspenluxxxy/nanorand-rs/blob/master/.github/workflows/tests.yml#L24). We're also getting to the point of cfg complexity where [something like `cfg_if!`](https://docs.rs/cfg-if/0/cfg_if/) is useful to prevent bugs like this at compile time.