### PR TITLE
fix: Rust code blocks' language tag in markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A library meant for fast, random number generation with quick compile time, and 
 
 ## Examples
 ### Generating a number
-```rs
+```rust
 use nanorand::{RNG, WyRand};
 
 fn main() {
@@ -17,7 +17,7 @@ fn main() {
 }
 ```
 ### Generating a number in a range
-```rs
+```rust
 use nanorand::{RNG, WyRand};
 
 fn main() {
@@ -26,7 +26,7 @@ fn main() {
 }
 ```
 ### Shuffling a Vec
-```rs
+```rust
 use nanorand::{RNG, WyRand};
 
 fn main() {


### PR DESCRIPTION
Switched language tags in markdown files from
~~~markdown
```rs
~~~
to
~~~markdown
```rust
~~~
Since the syntax highlighting wasn't working on my firefox
