### PR TITLE
fix forgotten refactor in default entropy backend

### DIFF
--- a/nanorand/src/entropy/mod.rs
+++ b/nanorand/src/entropy/mod.rs
@@ -49,8 +49,8 @@ pub fn entropy_from_system(out: &mut [u8]) {
 	target_os = "ios",
 	windows
 )))]
-pub fn entropy_from_system(out: &mut [u8]) -> Vec<u8> {
-	backup_entropy(out)
+pub fn entropy_from_system(out: &mut [u8]) {
+	backup_entropy(out);
 }
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
This notably prevented building on wasm.