### PR TITLE
Rewrite `gen::random_range` 

### DIFF
--- a/nanorand/src/gen.rs
+++ b/nanorand/src/gen.rs
@@ -1,3 +1,5 @@
+use std::u64;
+
 use crate::RNG;
 
 /// A trait used for generating a random object with an RNG,
@@ -48,15 +50,11 @@ impl<R: RNG> RandomGen<R> for u64 {
 
 impl<R: RNG> RandomRange<R> for u64 {
 	fn random_range(r: &mut R, lower: u64, upper: u64) -> Self {
-		let t = ((-(upper as i64)) % (upper as i64)) as u64;
-		let in_range = loop {
-			let x = Self::random(r);
-			let m = (x as u128).wrapping_mul(upper as u128);
-			if (m as u64) >= t {
-				break (m >> 64) as u64;
-			}
-		};
-		in_range.max(lower)
+		assert!(upper >= lower);
+		let n = (upper - lower) + 1;
+		let boundary = u64::MAX / n;
+		let random = Self::random(r);
+		(random / boundary) + lower
 	}
 }
 

--- a/nanorand/src/gen.rs
+++ b/nanorand/src/gen.rs
@@ -1,5 +1,3 @@
-use std::u64;
-
 use crate::RNG;
 
 /// A trait used for generating a random object with an RNG,

--- a/nanorand/src/gen.rs
+++ b/nanorand/src/gen.rs
@@ -51,6 +51,10 @@ impl<R: RNG> RandomGen<R> for u64 {
 impl<R: RNG> RandomRange<R> for u64 {
 	fn random_range(r: &mut R, lower: u64, upper: u64) -> Self {
 		assert!(upper >= lower);
+		if lower == 0 && upper == u64::MAX {
+			// avoid overflow
+			return Self::random(r);
+		}
 		let n = (upper - lower) + 1;
 		let boundary = u64::MAX / n;
 		let random = Self::random(r);

--- a/nanorand/src/rand/wyrand.rs
+++ b/nanorand/src/rand/wyrand.rs
@@ -77,3 +77,28 @@ impl Display for WyRand {
 		write!(f, "WyRand ({:p})", self)
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	// TDD for https://github.com/aspenluxxxy/nanorand-rs/issues/21
+	#[test]
+	fn generate_range_contains_upper_test() {
+		generate_range_contains_upper(0, 1);
+		generate_range_contains_upper(1000, 1010);
+		generate_range_contains_upper(u64::MAX - 1, u64::MAX);
+	}
+
+	fn generate_range_contains_upper(lower: u64, upper: u64) {
+		type T = u64;
+		let n = (((upper - lower) + 1) * 1000) as usize;
+		let mut rng = WyRand::new();
+		let mut buff: Vec<T> = Vec::with_capacity(n);
+		for _ in 0..n {
+			buff.push(rng.generate_range::<T>(lower, upper));
+		}
+		// we should get non-zero amount of `upper` and `lower` values by pure chance..
+		assert!(buff.contains(&lower));
+		assert!(buff.contains(&upper));
+	}
+}


### PR DESCRIPTION
This is a proposed fix to #21 

Basically rewritten to straight "down to earth" implementation, which maps the random `u64` value onto specified range. Not sure if that is the proper way to do this, but let's start a discussion