### PR TITLE
Fix compilation error when not specifying `wyrand` feature

### DIFF
--- a/nanorand/src/lib.rs
+++ b/nanorand/src/lib.rs
@@ -88,6 +88,6 @@ pub mod entropy;
 pub mod gen;
 /// RNG algorithms.
 pub mod rand;
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", feature = "wyrand"))]
 /// Provides a thread-local [WyRand] RNG.
 pub mod tls;

--- a/nanorand/src/lib.rs
+++ b/nanorand/src/lib.rs
@@ -88,6 +88,6 @@ pub mod entropy;
 pub mod gen;
 /// RNG algorithms.
 pub mod rand;
-#[cfg(all(feature = "std", feature = "wyrand"))]
+#[cfg(feature = "tls")]
 /// Provides a thread-local [WyRand] RNG.
 pub mod tls;


### PR DESCRIPTION
`tls` module requires `wyrand` feature, so we need `#[cfg(feature = "wyrand")]`
attribute for its module.