### PR TITLE
ci: run cargo check --no-default-features for #![no_std] cases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --no-default-features
+          args: --no-default-features --manifest-path=nanorand/Cargo.toml
       - name: Run 'cross test'
         uses: actions-rs/cargo@v1
         with:
@@ -61,7 +61,7 @@ jobs:
           uses: actions-rs/cargo@v1
           with:
             command: check
-            args: --no-default-features
+            args: --no-default-features --manifest-path=nanorand/Cargo.toml
         - name: Run 'cargo test'
           uses: actions-rs/cargo@v1
           with:
@@ -87,7 +87,7 @@ jobs:
           uses: actions-rs/cargo@v1
           with:
             command: check
-            args: --no-default-features
+            args: --no-default-features --manifest-path=nanorand/Cargo.toml
         - name: Run 'cargo test'
           uses: actions-rs/cargo@v1
           with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,16 @@ jobs:
           override: true
           profile: minimal
           toolchain: stable
+      - name: Run 'cargo check'
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --all-features
+      - name: Run 'cargo check --no-default-features'
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --no-default-features
       - name: Run 'cross test'
         uses: actions-rs/cargo@v1
         with:
@@ -33,7 +43,7 @@ jobs:
           - riscv64gc-unknown-linux-gnu
   windows-tests:
       name: Test on Windows
-      runs-on: windows-latest 
+      runs-on: windows-latest
       steps:
         - uses: actions/checkout@v2
         - name: Install stable Rust toolchain
@@ -42,6 +52,16 @@ jobs:
             override: true
             profile: minimal
             toolchain: stable
+        - name: Run 'cargo check'
+          uses: actions-rs/cargo@v1
+          with:
+            command: check
+            args: --all-features
+        - name: Run 'cargo check --no-default-features'
+          uses: actions-rs/cargo@v1
+          with:
+            command: check
+            args: --no-default-features
         - name: Run 'cargo test'
           uses: actions-rs/cargo@v1
           with:
@@ -49,7 +69,7 @@ jobs:
             args: --all-features
   macos-tests:
       name: Test on macOS
-      runs-on: macos-latest 
+      runs-on: macos-latest
       steps:
         - uses: actions/checkout@v2
         - name: Install stable Rust toolchain
@@ -58,6 +78,16 @@ jobs:
             override: true
             profile: minimal
             toolchain: stable
+        - name: Run 'cargo check'
+          uses: actions-rs/cargo@v1
+          with:
+            command: check
+            args: --all-features
+        - name: Run 'cargo check --no-default-features'
+          uses: actions-rs/cargo@v1
+          with:
+            command: check
+            args: --no-default-features
         - name: Run 'cargo test'
           uses: actions-rs/cargo@v1
           with:


### PR DESCRIPTION
Also, it maybe a good idea to run bare `cargo check` to fail fast with type error or so.

This is hopefully sufficient enough to fix #25.